### PR TITLE
feat: add support to configure branch name via env variable

### DIFF
--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -135,7 +135,7 @@ export default class MDXRuntimeTest extends React.Component {
             {docsLocation && ((editable && mdx.frontmatter.editable !== false) || mdx.frontmatter.editable === true) ? (
               <EditOnRepo
                 location={docsLocation}
-                branch={gitBranch.name}
+                branch={process.env.BOOGI_BRANCH || gitBranch.name}
                 path={mdx.parent.relativePath}
                 repoType={docsLocationType}
               />


### PR DESCRIPTION
In Gitlab it seems that it is using the Git hash instead of the branch name. With this feature we could leave it up to the user.